### PR TITLE
feat: advanced futuristic redesign + fixes

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -11,13 +11,15 @@ service cloud.firestore {
     // Users can read and write their own profile data.
     // Admins can read any user's profile.
     match /users/{userId} {
-      allow read, write: if request.auth.uid == userId;
-      allow get, list: if isAdmin();
+      // Users can read and write their own profile; admins can read any profile.
+      allow read: if request.auth.uid == userId || isAdmin();
+      allow write: if request.auth.uid == userId;
 
       // Users can manage their own draft. Admins can read any document.
       match /application/{appId} {
-        allow read, write: if request.auth.uid == userId && appId == 'draft';
-        allow get, list: if isAdmin();
+        // Allow users to manage their own draft and admins to read any draft.
+        allow read: if (request.auth.uid == userId && appId == 'draft') || isAdmin();
+        allow write: if request.auth.uid == userId && appId == 'draft';
       }
       
       // Users can write to their own payments subcollection. Admins can read.

--- a/src/context/application-context.tsx
+++ b/src/context/application-context.tsx
@@ -12,6 +12,7 @@ import type { BackgroundFormValues } from '@/components/forms/background-form';
 import { useAuth } from './auth-context';
 import type { College } from '@/lib/college-data';
 import { db } from '@/lib/firebase';
+import { removeUndefinedFields } from '@/lib/utils';
 import { doc, onSnapshot, setDoc, serverTimestamp } from 'firebase/firestore';
 
 export interface UploadedFile {
@@ -181,11 +182,15 @@ export const ApplicationProvider = ({ children }: { children: ReactNode }) => {
 
     const docRef = doc(db, 'users', user.uid, 'application', 'draft');
     try {
-      await setDoc(docRef, {
-        selectedCollege: college,
-        studyPlan: newStudyPlanForDb!,
-        updatedAt: serverTimestamp()
-      }, { merge: true });
+      await setDoc(
+        docRef,
+        {
+          selectedCollege: college,
+          studyPlan: removeUndefinedFields(newStudyPlanForDb!),
+          updatedAt: serverTimestamp(),
+        },
+        { merge: true }
+      );
     } catch (error) {
       console.error("Error updating college/program:", error);
     }
@@ -199,7 +204,13 @@ export const ApplicationProvider = ({ children }: { children: ReactNode }) => {
 
     const docRef = doc(db, 'users', user.uid, 'application', 'draft');
     try {
-      await setDoc(docRef, { ...initialApplicationData, updatedAt: serverTimestamp() });
+      await setDoc(
+        docRef,
+        {
+          ...removeUndefinedFields(initialApplicationData),
+          updatedAt: serverTimestamp(),
+        }
+      );
     } catch (error) {
       console.error("Error resetting application data:", error);
     }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,18 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// Recursively remove all properties with `undefined` values from an object.
+export function removeUndefinedFields<T>(obj: T): T {
+  if (obj === null || typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) {
+    return obj.map((item) => removeUndefinedFields(item)) as unknown as T;
+  }
+  const result: Record<string, any> = {};
+  Object.entries(obj).forEach(([key, value]) => {
+    if (value !== undefined) {
+      result[key] = removeUndefinedFields(value as any);
+    }
+  });
+  return result as T;
+}


### PR DESCRIPTION
## Summary
- sanitize undefined values before Firestore writes
- allow admins to read user application drafts

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities and others)*
- `npm run typecheck` *(fails: TS2769 Firestore null errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a38cd14a883239ccf2e213d9ce289