### PR TITLE
Implement messaging and style updates

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -17,9 +17,19 @@ service cloud.firestore {
 
       // Users can manage their own draft. Admins can read any document.
       match /application/{appId} {
-        // Allow users to manage their own draft and admins to read any draft.
+        // Allow users to manage their own draft and admins to read or write any draft.
         allow read: if (request.auth.uid == userId && appId == 'draft') || isAdmin();
-        allow write: if request.auth.uid == userId && appId == 'draft';
+        allow write: if (request.auth.uid == userId && appId == 'draft') || isAdmin();
+      }
+
+      // Allow users and admins to access uploaded documents
+      match /documents/{docId} {
+        allow read, write: if request.auth.uid == userId || isAdmin();
+      }
+
+      // Messages between user and admin
+      match /messages/{msgId} {
+        allow read, write: if request.auth.uid == userId || isAdmin();
       }
       
       // Users can write to their own payments subcollection. Admins can read.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -84,13 +84,40 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-offWhite text-deepNavy antialiased;
     font-feature-settings: "rlig" 1, "calt" 1;
+  }
+  .dark body {
+    @apply bg-deepNavy text-offWhite;
   }
 }
 
 @layer utilities {
   .text-balance {
     text-wrap: balance;
+  }
+  .card {
+    @apply bg-white dark:bg-[#15204A] rounded-2xl shadow-xl p-6;
+  }
+  .btn-primary {
+    @apply bg-electricViolet text-white font-semibold py-3 px-6 rounded-full transform transition hover:scale-105 hover:shadow-2xl hover:animate-glow-pulse;
+  }
+  .btn-accent {
+    @apply bg-electricTeal text-white font-semibold py-3 px-6 rounded-full transform transition hover:scale-105;
+  }
+  .link-futuristic {
+    @apply inline-block text-electricViolet dark:text-electricTeal relative after:content-[''] after:absolute after:bottom-0 after:left-0 after:w-0 after:h-0.5 after:bg-electricViolet dark:after:bg-electricTeal after:transition after:duration-300 hover:after:w-full;
+  }
+  .loader-shimmer {
+    @apply bg-gradient-to-r from-transparent via-slateGray to-transparent bg-[length:200%_100%] animate-gradient-pan;
+  }
+  .bg-texture {
+    background-image: repeating-linear-gradient(
+      45deg,
+      rgba(0,0,0,0.05) 0,
+      rgba(0,0,0,0.05) 2px,
+      transparent 2px,
+      transparent 4px
+    );
   }
 }

--- a/src/context/application-context.tsx
+++ b/src/context/application-context.tsx
@@ -156,7 +156,7 @@ export const ApplicationProvider = ({ children }: { children: ReactNode }) => {
     const docRef = doc(db, 'users', user.uid, 'application', 'draft');
     try {
       // Add updatedAt timestamp to track changes for drafts
-      const sanitized = Object.fromEntries(Object.entries(data).filter(([_, v]) => v !== undefined));
+      const sanitized = removeUndefinedFields(data);
       await setDoc(docRef, { [step]: sanitized, updatedAt: serverTimestamp() }, { merge: true });
     } catch (error) {
       console.error("Error updating application step data:", error);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,7 +2,7 @@
 import type {Config} from 'tailwindcss';
 
 export default {
-  darkMode: ['class'],
+  darkMode: 'class',
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
@@ -62,8 +62,13 @@ export default {
           DEFAULT: 'hsl(var(--card))',
           foreground: 'hsl(var(--card-foreground))',
         },
-        'electric-violet': '#8A2BE2',
-        'electric-teal': '#20CFFD',
+        electricViolet: '#8A2BE2',
+        electricTeal: '#20CFFD',
+        neonPink: '#FF49DB',
+        cyberYellow: '#FFD300',
+        deepNavy: '#0B1D58',
+        slateGray: '#708090',
+        offWhite: '#F2F4F8',
       },
       borderRadius: {
         lg: 'var(--radius)',
@@ -105,23 +110,32 @@ export default {
                 transform: 'translateY(0)'
             },
         },
+        'slide-up': {
+          '0%': { transform: 'translateY(20px)' },
+          '100%': { transform: 'translateY(0)' },
+        },
+        'glow-pulse': {
+          '0%,100%': { boxShadow: '0 0 8px #8A2BE2' },
+          '50%': { boxShadow: '0 0 20px #8A2BE2' },
+        },
+        'gradient-pan': {
+          '0%': { backgroundPosition: '0% 50%' },
+          '100%': { backgroundPosition: '100% 50%' },
+        },
         'background-pan': {
-          '0%': {
-            'background-position': '0% 50%',
-          },
-          '50%': {
-            'background-position': '100% 50%',
-          },
-          '100%': {
-            'background-position': '0% 50%',
-          }
-        }
+          '0%': { 'background-position': '0% 50%' },
+          '50%': { 'background-position': '100% 50%' },
+          '100%': { 'background-position': '0% 50%' },
+        },
       },
       animation: {
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
-        'fade-in': 'fade-in 0.5s ease-out forwards',
-        'fade-in-up': 'fade-in-up 0.5s ease-out forwards',
+        'fade-in': 'fade-in 0.5s ease-out',
+        'fade-in-up': 'fade-in-up 0.5s ease-out',
+        'slide-up': 'slide-up 0.6s ease-out',
+        'glow-pulse': 'glow-pulse 2s ease-in-out infinite',
+        'gradient-pan': 'gradient-pan 12s ease infinite',
         'background-pan': 'background-pan 15s ease-in-out infinite',
       },
     },


### PR DESCRIPTION
## Summary
- add futuristic color palette and animation utilities
- style global body and utility classes
- filter undefined values when writing application step data
- allow admins to send dashboard messages
- show recent messages on the dashboard
- relax Firestore rules for drafts, docs and messages

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities and other lint errors)*
- `npm run typecheck` *(fails: Firestore null parameter errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a4007961c8323a30eebe028f89236