### PR TITLE
Fix Firestore permission error on admin pages

### DIFF
--- a/src/components/admin/admin-layout.tsx
+++ b/src/components/admin/admin-layout.tsx
@@ -128,14 +128,18 @@ function AdminPageSkeleton() {
 
 export function AdminLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
-  const { loading: isAuthLoading, user } = useAuth();
+  const { loading: isAuthLoading, user, isAdmin } = useAuth();
   const router = useRouter();
 
   React.useEffect(() => {
-    if (!isAuthLoading && !user) {
+    if (isAuthLoading) return;
+
+    if (!user) {
       router.replace('/admin/login');
+    } else if (!isAdmin) {
+      router.replace('/dashboard');
     }
-  }, [isAuthLoading, user, router]);
+  }, [isAuthLoading, user, isAdmin, router]);
 
   return (
     <SidebarProvider>


### PR DESCRIPTION
## Summary
- prevent non-admin users from accessing admin pages by redirecting them

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities etc.)*
- `npm run typecheck` *(fails: type errors in notifications-context.tsx)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b9acbf8808323b2ca6795ff4bdf3d