### PR TITLE
Improve localization, learning hub, and forum

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -75,5 +75,10 @@ service cloud.firestore {
       // Only admins can change general settings.
       allow write: if isAdmin();
     }
+
+    // Rules for the 'forum' collection
+    match /forum/{postId} {
+      allow read, write: if request.auth != null;
+    }
   }
 }

--- a/src/app/forum/page.tsx
+++ b/src/app/forum/page.tsx
@@ -1,14 +1,14 @@
 'use client';
 import { AppLayout } from '@/components/app-layout';
 import { useEffect, useState } from 'react';
-import { collection, addDoc, onSnapshot, query, orderBy, serverTimestamp } from 'firebase/firestore';
+import { collection, addDoc, onSnapshot, query, orderBy, serverTimestamp, updateDoc, doc, increment } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import { useAuth } from '@/context/auth-context';
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 
-interface Post { id: string; author: string; content: string; timestamp: any; }
+interface Post { id: string; author: string; content: string; timestamp: any; likes?: number; }
 
 export default function ForumPage() {
   const { user } = useAuth();
@@ -29,8 +29,13 @@ export default function ForumPage() {
       author: user.displayName || user.email,
       content: newPost.trim(),
       timestamp: serverTimestamp(),
+      likes: 0,
     });
     setNewPost('');
+  };
+
+  const likePost = async (id: string) => {
+    await updateDoc(doc(db, 'forum', id), { likes: increment(1) });
   };
 
   return (
@@ -45,11 +50,17 @@ export default function ForumPage() {
           {posts.map(p => (
             <Card key={p.id}>
               <CardHeader>
-                <CardTitle className="text-sm">{p.author} <span className="text-xs text-muted-foreground">{p.timestamp?.toDate?.().toLocaleString?.()}</span></CardTitle>
+                <CardTitle className="text-sm">{p.author}</CardTitle>
               </CardHeader>
               <CardContent>
                 <p>{p.content}</p>
               </CardContent>
+              <CardFooter className="justify-between">
+                <span className="text-xs text-muted-foreground">{p.timestamp?.toDate?.().toLocaleString?.()}</span>
+                <Button variant="ghost" size="sm" onClick={() => likePost(p.id)}>
+                  👍 {p.likes ?? 0}
+                </Button>
+              </CardFooter>
             </Card>
           ))}
         </div>

--- a/src/context/locale-context.tsx
+++ b/src/context/locale-context.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useState, useEffect } from 'react';
 
 const translations = {
   en: {
@@ -38,7 +38,20 @@ const LocaleContext = createContext<LocaleContextValue>({
 });
 
 export function LocaleProvider({ children }: { children: React.ReactNode }) {
-  const [locale, setLocale] = useState<'en' | 'fr' | 'sw' | 'am'>('en');
+  const [locale, setLocale] = useState<'en' | 'fr' | 'sw' | 'am'>(() => {
+    if (typeof window !== 'undefined') {
+      return (
+        (localStorage.getItem('locale') as 'en' | 'fr' | 'sw' | 'am') || 'en'
+      );
+    }
+    return 'en';
+  });
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('locale', locale);
+      document.documentElement.lang = locale;
+    }
+  }, [locale]);
   const t = (key: keyof typeof translations['en']) => translations[locale][key] || key;
   return (
     <LocaleContext.Provider value={{ locale, setLocale, t }}>

--- a/src/lib/learning-modules.ts
+++ b/src/lib/learning-modules.ts
@@ -36,4 +36,20 @@ export const learningModules: LearningModule[] = [
       { question: 'How many hours per week can you work on a study permit?', options: ['10', '20', '40'], answer: 1 },
     ],
   },
+  {
+    id: 'healthcare-insurance',
+    title: 'Health Insurance for Students',
+    content: `Discover the healthcare coverage options available for international students in Canada, including provincial plans and private insurance.`,
+    quiz: [
+      { question: 'What document typically grants access to provincial health coverage?', options: ['Study Permit', 'Driver License', 'Work Contract'], answer: 0 },
+    ],
+  },
+  {
+    id: 'permanent-residency',
+    title: 'Pathways to Permanent Residency',
+    content: `Learn about programs like the Post-Graduation Work Permit and Express Entry that can lead to staying in Canada permanently.`,
+    quiz: [
+      { question: 'Which program lets you work after you finish studies?', options: ['Working Holiday', 'Post-Graduation Work Permit', 'Visitor Visa'], answer: 1 },
+    ],
+  },
 ];


### PR DESCRIPTION
## Summary
- persist locale selection in localStorage and update document language
- expand learning hub with new modules
- add like feature to forum posts
- allow authenticated forum access in Firestore rules

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities and others)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b9e0ca8c08323a338204a179e7e2e