### PR TITLE
feat: apply new design palette and fonts

### DIFF
--- a/src/app/fonts.ts
+++ b/src/app/fonts.ts
@@ -1,8 +1,23 @@
 
-import { Inter } from 'next/font/google';
+import { Inter, Inter_Tight, Space_Grotesk } from 'next/font/google';
 
 export const inter = Inter({
   subsets: ['latin'],
+  weight: ['400', '500'],
   variable: '--font-inter',
+  display: 'swap',
+});
+
+export const interTight = Inter_Tight({
+  subsets: ['latin'],
+  weight: ['700', '800', '900'],
+  variable: '--font-inter-tight',
+  display: 'swap',
+});
+
+export const spaceGrotesk = Space_Grotesk({
+  subsets: ['latin'],
+  weight: ['500'],
+  variable: '--font-space-grotesk',
   display: 'swap',
 });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,40 +5,40 @@
 
 @layer base {
   :root {
-    --background: 222 84% 4.9%; /* Dark Mode: Charcoal Black */
-    --foreground: 210 40% 98%;     /* Dark Mode: Almost White Text */
- 
-    --card: 222 74% 9.5%;
+    --background: 220 58% 10%; /* Midnight Navy */
+    --foreground: 210 40% 98%; /* Snow */
+
+    --card: 218 37% 13%; /* Carbon */
     --card-foreground: 210 40% 98%;
- 
-    --popover: 222 84% 4.9%;
+
+    --popover: 218 37% 13%;
     --popover-foreground: 210 40% 98%;
- 
-    --primary: 210 40% 98%;
-    --primary-foreground: 222 47.4% 11.2%;
- 
-    --secondary: 217.2 32.6% 17.5%;
+
+    --primary: 355 78% 56%; /* Maple Red */
+    --primary-foreground: 210 40% 98%;
+
+    --secondary: 268 100% 58%; /* Violet Electric */
     --secondary-foreground: 210 40% 98%;
- 
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
- 
-    --accent: 217.2 32.6% 17.5%;
+
+    --muted: 218 37% 13%;
+    --muted-foreground: 214 32% 91%; /* Polar */
+
+    --accent: 268 100% 58%;
     --accent-foreground: 210 40% 98%;
- 
+
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
 
-    --success: 142.1 70.2% 30%;
-    --success-foreground: 0 0% 98%;
+    --success: 152 87% 60%; /* Lime Ice */
+    --success-foreground: 0 0% 15%;
 
     --warning: 40 92% 50%;
     --warning-foreground: 240 10% 3.9%;
 
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 210 40% 98%;
- 
+    --border: 214 32% 91%;
+    --input: 214 32% 91%;
+    --ring: 268 100% 58%;
+
     --radius: 0.5rem;
   }
 }
@@ -57,22 +57,22 @@
   .text-balance {
     text-wrap: balance;
   }
-  .text-electric-violet {
-    color: theme('colors.electricViolet');
+  .text-violet-electric {
+    color: theme('colors.violetElectric');
   }
-  .bg-electric-violet {
-    background-color: theme('colors.electricViolet');
+  .bg-violet-electric {
+    background-color: theme('colors.violetElectric');
   }
   .btn-primary {
-    @apply bg-electric-violet text-white font-semibold py-3 px-4 rounded-md transition-colors hover:bg-electric-violet;
+    @apply bg-violet-electric text-white font-semibold py-3 px-4 rounded-md transition-colors hover:bg-violet-electric;
   }
 }
 @layer components {
   .hub-card {
-    @apply bg-white dark:bg-[#15204A] rounded-2xl shadow-md p-6 transition transform hover:scale-105 animate-fade-in;
+    @apply bg-white dark:bg-card rounded-2xl shadow-md p-6 transition transform hover:scale-105 animate-fade-in;
   }
   .hub-card-icon {
-    @apply text-electricTeal text-4xl mb-4;
+    @apply text-violet-electric text-4xl mb-4;
   }
   .hub-card-title {
     @apply text-xl font-semibold mb-2;
@@ -81,10 +81,10 @@
     @apply text-base leading-relaxed;
   }
   .hub-input {
-    @apply bg-white dark:bg-[#15204A] border border-slateGray text-foreground rounded-md px-3 py-2;
+    @apply bg-white dark:bg-card border border-border text-foreground rounded-md px-3 py-2;
   }
-  .post-card { @apply bg-white dark:bg-[#15204A] rounded-xl shadow p-4 animate-slide-up; }
-  .post-author { @apply font-semibold text-electricViolet; }
-  .post-time   { @apply text-sm text-slateGray; }
+  .post-card { @apply bg-white dark:bg-card rounded-xl shadow p-4 animate-slide-up; }
+  .post-author { @apply font-semibold text-violet-electric; }
+  .post-time   { @apply text-sm text-polar; }
   .post-body   { @apply mt-2 text-base; }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,7 @@ import { AuthProvider } from '@/context/auth-context';
 import { LocaleProvider } from '@/context/locale-context';
 import { NotificationsProvider } from '@/context/notifications-context';
 import { cn } from '@/lib/utils';
-import { inter } from './fonts';
+import { inter, interTight, spaceGrotesk } from './fonts';
 
 export const metadata: Metadata = {
   title: 'Maple Leafs Education',
@@ -56,6 +56,8 @@ export default function RootLayout({
       <body className={cn(
         "font-sans antialiased",
         inter.variable,
+        interTight.variable,
+        spaceGrotesk.variable,
       )}>
         <AuthProvider>
           <LocaleProvider>

--- a/src/components/marketing/site-header.tsx
+++ b/src/components/marketing/site-header.tsx
@@ -11,9 +11,9 @@ import { useState } from 'react';
 
 const navLinks = [
     { href: "/#how-it-works", label: "How It Works" },
-    { href: "/#testimonials", label: "Testimonials" },
     { href: "/pricing", label: "Pricing" },
-    { href: "/about", label: "About" },
+    { href: "/#success-stories", label: "Success Stories" },
+    { href: "/resources", label: "Resources" },
     { href: "/support", label: "Support" },
 ];
 
@@ -51,10 +51,10 @@ export function SiteHeader() {
               ) : (
                 <div className="hidden md:flex md:items-center md:space-x-2">
                   <Button asChild variant="ghost">
-                     <Link href="/login">Log In</Link>
+                     <Link href="/login">Sign In</Link>
                   </Button>
                    <Button asChild>
-                     <Link href="/signup">Sign Up</Link>
+                     <Link href="/signup">Get Started</Link>
                   </Button>
                 </div>
               )}
@@ -87,8 +87,8 @@ export function SiteHeader() {
                     {!user && !loading && (
                         <>
                             <hr className="my-2" />
-                             <Link href="/login" className="text-muted-foreground transition-colors hover:text-foreground text-lg" onClick={() => setIsOpen(false)}>Log In</Link>
-                             <Link href="/signup" className="text-muted-foreground transition-colors hover:text-foreground text-lg" onClick={() => setIsOpen(false)}>Sign Up</Link>
+                             <Link href="/login" className="text-muted-foreground transition-colors hover:text-foreground text-lg" onClick={() => setIsOpen(false)}>Sign In</Link>
+                             <Link href="/signup" className="text-muted-foreground transition-colors hover:text-foreground text-lg" onClick={() => setIsOpen(false)}>Get Started</Link>
                         </>
                     )}
                 </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,12 +13,14 @@ export default {
       center: true,
       padding: '2rem',
       screens: {
-        '2xl': '1400px',
+        '2xl': '1280px',
       },
     },
     extend: {
       fontFamily: {
         sans: ['var(--font-inter)', 'sans-serif'],
+        heading: ['var(--font-inter-tight)', 'sans-serif'],
+        ui: ['var(--font-space-grotesk)', 'sans-serif'],
       },
       colors: {
         border: 'hsl(var(--border))',
@@ -62,13 +64,13 @@ export default {
           DEFAULT: 'hsl(var(--card))',
           foreground: 'hsl(var(--card-foreground))',
         },
-        electricViolet: '#8A2BE2',
-        electricTeal: '#20CFFD',
-        neonPink: '#FF49DB',
-        cyberYellow: '#FFD300',
-        deepNavy: '#0B1D58',
-        slateGray: '#708090',
-        offWhite: '#F2F4F8',
+        midnightNavy: '#0B1529',
+        carbon: '#151E2E',
+        snow: '#F8FAFC',
+        polar: '#E2E8F0',
+        mapleRed: '#E63946',
+        violetElectric: '#8E2AFF',
+        limeIce: '#3EF29D',
       },
       borderRadius: {
         lg: 'var(--radius)',


### PR DESCRIPTION
## Summary
- add Inter Tight and Space Grotesk fonts and expose them via Tailwind
- implement Midnight Navy-based color palette and update utility classes
- refresh marketing header links and CTA text

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: react/no-unescaped-entities, etc.)*
- `npm run typecheck` *(fails: Firestore type mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68921545d7208323b46fbe1fa246c723