### PR TITLE
feat: introduce display font and updated palette

### DIFF
--- a/src/app/fonts.ts
+++ b/src/app/fonts.ts
@@ -1,10 +1,17 @@
 
-import { Inter, Inter_Tight, Space_Grotesk } from 'next/font/google';
+import { Anton, Inter, Inter_Tight, Space_Grotesk } from 'next/font/google';
 
 export const inter = Inter({
   subsets: ['latin'],
   weight: ['400', '500'],
   variable: '--font-inter',
+  display: 'swap',
+});
+
+export const anton = Anton({
+  subsets: ['latin'],
+  weight: ['400'],
+  variable: '--font-anton',
   display: 'swap',
 });
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,39 +5,39 @@
 
 @layer base {
   :root {
-    --background: 220 58% 10%; /* Midnight Navy */
-    --foreground: 210 40% 98%; /* Snow */
+    --background: 0 0% 6%; /* Off-Black */
+    --foreground: 0 0% 100%; /* White */
 
-    --card: 218 37% 13%; /* Carbon */
-    --card-foreground: 210 40% 98%;
+    --card: 0 0% 10%;
+    --card-foreground: 0 0% 100%;
 
-    --popover: 218 37% 13%;
-    --popover-foreground: 210 40% 98%;
+    --popover: 0 0% 10%;
+    --popover-foreground: 0 0% 100%;
 
     --primary: 355 78% 56%; /* Maple Red */
-    --primary-foreground: 210 40% 98%;
+    --primary-foreground: 0 0% 100%;
 
-    --secondary: 268 100% 58%; /* Violet Electric */
-    --secondary-foreground: 210 40% 98%;
+    --secondary: 231 100% 55%; /* Tech Blue */
+    --secondary-foreground: 0 0% 100%;
 
-    --muted: 218 37% 13%;
-    --muted-foreground: 214 32% 91%; /* Polar */
+    --muted: 0 0% 20%;
+    --muted-foreground: 234 11% 79%; /* Grid Gray */
 
-    --accent: 268 100% 58%;
-    --accent-foreground: 210 40% 98%;
+    --accent: 48 100% 50%; /* Signal Yellow */
+    --accent-foreground: 0 0% 0%;
 
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
+    --destructive: 355 78% 40%;
+    --destructive-foreground: 0 0% 100%;
 
-    --success: 152 87% 60%; /* Lime Ice */
+    --success: 152 87% 60%;
     --success-foreground: 0 0% 15%;
 
-    --warning: 40 92% 50%;
+    --warning: 48 100% 50%;
     --warning-foreground: 240 10% 3.9%;
 
-    --border: 214 32% 91%;
-    --input: 214 32% 91%;
-    --ring: 268 100% 58%;
+    --border: 234 11% 79%; /* Grid Gray */
+    --input: 234 11% 79%;
+    --ring: 231 100% 55%;
 
     --radius: 0.5rem;
   }
@@ -48,7 +48,7 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground antialiased;
+    @apply bg-background text-foreground antialiased font-body;
     font-feature-settings: "rlig" 1, "calt" 1;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,7 @@ import { AuthProvider } from '@/context/auth-context';
 import { LocaleProvider } from '@/context/locale-context';
 import { NotificationsProvider } from '@/context/notifications-context';
 import { cn } from '@/lib/utils';
-import { inter, interTight, spaceGrotesk } from './fonts';
+import { anton, inter, spaceGrotesk } from './fonts';
 
 export const metadata: Metadata = {
   title: 'Maple Leafs Education',
@@ -54,9 +54,9 @@ export default function RootLayout({
         />
       </head>
       <body className={cn(
-        "font-sans antialiased",
+        "font-body antialiased",
         inter.variable,
-        interTight.variable,
+        anton.variable,
         spaceGrotesk.variable,
       )}>
         <AuthProvider>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -63,15 +63,15 @@ export default function MarketingPage() {
               <MoveRight className="ml-2 h-4 w-4" />
             </Badge>
             <div className="max-w-3xl mx-auto">
-              <h1 className="text-4xl md:text-5xl lg:text-6xl font-black tracking-tighter text-foreground text-balance animate-fade-in-up [animation-delay:400ms]">
+              <h1 className="text-4xl md:text-5xl lg:text-6xl font-display tracking-tighter text-foreground text-balance animate-fade-in-up [animation-delay:400ms]">
                 Your Smartest Path to a Canadian Education
               </h1>
               <p className="mt-6 max-w-2xl mx-auto text-lg md:text-xl text-muted-foreground text-balance animate-fade-in-up [animation-delay:600ms]">
                 Navigate study permit caps and find the perfect college with our AI-powered platform, guided by certified immigration consultants.
               </p>
               <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center animate-fade-in-up [animation-delay:800ms]">
-                <Button asChild size="lg" className="font-semibold text-base bg-electric-violet hover:bg-electric-violet/90 text-white shadow-lg transition-transform duration-200 hover:scale-105">
-                  <Link href="/signup">Check Eligibility Free <ArrowRight className="ml-2 h-5 w-5" /></Link>
+                <Button asChild size="lg" className="font-semibold text-base bg-primary hover:bg-primary/90 text-white shadow-lg transition-transform duration-200 hover:scale-105">
+                  <Link href="/signup">Get Started for Free <ArrowRight className="ml-2 h-5 w-5" /></Link>
                 </Button>
                 <Button asChild size="lg" variant="ghost" className="transition-colors duration-200 hover:bg-primary/10">
                    <Link href="/pricing">View Pricing</Link>
@@ -85,9 +85,9 @@ export default function MarketingPage() {
         <section id="how-it-works" className="w-full py-12 md:py-24 bg-card">
           <div className="container mx-auto px-4 md:px-6">
             <div className="text-center mb-16">
-              <h2 className="text-3xl font-black tracking-tight sm:text-4xl text-balance">Your Application Journey, Simplified</h2>
+              <h2 className="text-3xl font-display tracking-tight sm:text-4xl text-balance">Your Application Journey, Simplified</h2>
               <p className="max-w-2xl mx-auto mt-4 text-muted-foreground md:text-lg text-balance">
-                We've distilled the complex study permit process into a clear, intelligent, and guided path to success.
+                We&apos;ve distilled the complex study permit process into a clear, intelligent, and guided path to success.
               </p>
             </div>
             <div className="mx-auto grid max-w-5xl gap-10 sm:grid-cols-2 lg:grid-cols-4">
@@ -95,8 +95,8 @@ export default function MarketingPage() {
                 <div className="flex items-center justify-center mb-4 h-16 w-16 rounded-full bg-primary/10 mx-auto ring-4 ring-primary/20">
                   <BarChart className="h-8 w-8 text-primary" />
                 </div>
-                <h3 className="text-xl font-bold">1. Assess Profile</h3>
-                <p className="text-muted-foreground mt-2">Take our free Eligibility Quiz to instantly see your application strength and get an AI-generated action plan.</p>
+                <h3 className="text-xl font-bold">1. Create Profile</h3>
+                <p className="text-muted-foreground mt-2">Create your free profile to instantly see your application strength and get an AI-generated action plan.</p>
               </div>
               <div className="text-center p-6 rounded-lg hover:bg-background transition-colors duration-300">
                 <div className="flex items-center justify-center mb-4 h-16 w-16 rounded-full bg-primary/10 mx-auto ring-4 ring-primary/20">
@@ -127,7 +127,7 @@ export default function MarketingPage() {
         <section id="testimonials" className="w-full py-12 md:py-24 bg-background">
           <div className="container mx-auto px-4 md:px-6">
             <div className="text-center mb-12">
-              <h2 className="text-3xl font-black tracking-tight sm:text-4xl text-balance">Success Stories from Students Like You</h2>
+              <h2 className="text-3xl font-display tracking-tight sm:text-4xl text-balance">Success Stories from Students Like You</h2>
               <p className="max-w-2xl mx-auto mt-4 text-muted-foreground md:text-lg text-balance">
                 See how Maple Leafs Education has helped students from around the world achieve their Canadian dreams.
               </p>
@@ -154,7 +154,7 @@ export default function MarketingPage() {
                       ))}
                     </div>
                     <h4 className="font-semibold text-lg mb-2">{testimonial.title}</h4>
-                    <p className="text-muted-foreground text-sm">"{testimonial.story}"</p>
+                    <p className="text-muted-foreground text-sm">&ldquo;{testimonial.story}&rdquo;</p>
                   </CardContent>
                 </Card>
               ))}
@@ -166,12 +166,12 @@ export default function MarketingPage() {
         <section className="w-full py-20 md:py-32 bg-card">
            <div className="container mx-auto px-4 md:px-6 text-center">
             <div className="max-w-2xl mx-auto">
-                <h2 className="text-3xl md:text-4xl font-black tracking-tight text-balance">Ready to Start Your Journey?</h2>
+                <h2 className="text-3xl md:text-4xl font-display tracking-tight text-balance">Ready to Start Your Journey?</h2>
                 <p className="mt-4 text-lg text-muted-foreground text-balance">
-                    Your Canadian education is closer than you think. Take the first step today by checking your eligibility. It's free, fast, and gives you a clear action plan.
+                    Your Canadian education is closer than you think. Take the first step today by creating your profile. It&apos;s free, fast, and gives you a clear action plan.
                 </p>
                 <div className="mt-8">
-                    <Button asChild size="lg" className="font-semibold text-base w-full sm:w-auto bg-electric-violet hover:bg-electric-violet/90 text-white shadow-lg transition-transform duration-200 hover:scale-105">
+                    <Button asChild size="lg" className="font-semibold text-base w-full sm:w-auto bg-primary hover:bg-primary/90 text-white shadow-lg transition-transform duration-200 hover:scale-105">
                         <Link href="/signup">Get Started for Free</Link>
                     </Button>
                 </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,8 +18,8 @@ export default {
     },
     extend: {
       fontFamily: {
-        sans: ['var(--font-inter)', 'sans-serif'],
-        heading: ['var(--font-inter-tight)', 'sans-serif'],
+        body: ['var(--font-inter)', 'sans-serif'],
+        display: ['var(--font-anton)', 'sans-serif'],
         ui: ['var(--font-space-grotesk)', 'sans-serif'],
       },
       colors: {
@@ -64,13 +64,14 @@ export default {
           DEFAULT: 'hsl(var(--card))',
           foreground: 'hsl(var(--card-foreground))',
         },
-        midnightNavy: '#0B1529',
-        carbon: '#151E2E',
-        snow: '#F8FAFC',
-        polar: '#E2E8F0',
+        offBlack: '#0F0F0F',
+        white: '#FFFFFF',
+        techBlue: '#1A3CFF',
+        gridGray: '#C5C6D0',
         mapleRed: '#E63946',
+        signalYellow: '#FFCC00',
         violetElectric: '#8E2AFF',
-        limeIce: '#3EF29D',
+        'electric-violet': '#8E2AFF',
       },
       borderRadius: {
         lg: 'var(--radius)',


### PR DESCRIPTION
## Summary
- add Anton display font and expose via Tailwind
- implement redesigned color palette and body font wiring
- apply new typography and primary color to marketing page hero and CTA
- remove references to stand-alone Eligibility Quiz and escape entities for lint compliance

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities and other existing lint errors)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68927b04d06c83238117199cbd646738