### PR TITLE
Add showcase components and streamline color palette

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,11 +26,13 @@
     --accent: 48 100% 50%; /* Signal Yellow */
     --accent-foreground: 0 0% 0%;
 
+    --gold: 51 100% 50%;
+
     --destructive: 355 78% 40%;
     --destructive-foreground: 0 0% 100%;
 
-    --success: 152 87% 60%;
-    --success-foreground: 0 0% 15%;
+    --success: 231 100% 55%;
+    --success-foreground: 0 0% 100%;
 
     --warning: 48 100% 50%;
     --warning-foreground: 240 10% 3.9%;
@@ -57,14 +59,8 @@
   .text-balance {
     text-wrap: balance;
   }
-  .text-violet-electric {
-    color: theme('colors.violetElectric');
-  }
-  .bg-violet-electric {
-    background-color: theme('colors.violetElectric');
-  }
   .btn-primary {
-    @apply bg-violet-electric text-white font-semibold py-3 px-4 rounded-md transition-colors hover:bg-violet-electric;
+    @apply bg-techBlue text-white font-semibold py-3 px-4 rounded-md transition-colors hover:bg-techBlue;
   }
 }
 @layer components {
@@ -72,7 +68,7 @@
     @apply bg-white dark:bg-card rounded-2xl shadow-md p-6 transition transform hover:scale-105 animate-fade-in;
   }
   .hub-card-icon {
-    @apply text-violet-electric text-4xl mb-4;
+    @apply text-techBlue text-4xl mb-4;
   }
   .hub-card-title {
     @apply text-xl font-semibold mb-2;
@@ -84,7 +80,7 @@
     @apply bg-white dark:bg-card border border-border text-foreground rounded-md px-3 py-2;
   }
   .post-card { @apply bg-white dark:bg-card rounded-xl shadow p-4 animate-slide-up; }
-  .post-author { @apply font-semibold text-violet-electric; }
+  .post-author { @apply font-semibold text-techBlue; }
   .post-time   { @apply text-sm text-polar; }
   .post-body   { @apply mt-2 text-base; }
 }

--- a/src/app/showcase/page.tsx
+++ b/src/app/showcase/page.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Marquee } from '@/components/showcase/marquee';
+import { BentoGrid } from '@/components/showcase/bento-grid';
+import { AnimatedList } from '@/components/showcase/animated-list';
+import { Dock } from '@/components/showcase/dock';
+import { Globe } from '@/components/showcase/globe';
+import { IconCloud } from '@/components/showcase/icon-cloud';
+import { AnimatedBeam } from '@/components/showcase/animated-beam';
+import { BorderBeam } from '@/components/showcase/border-beam';
+import { Meteors } from '@/components/showcase/meteors';
+import { PixelImage } from '@/components/showcase/pixel-image';
+
+export default function ShowcasePage() {
+  return (
+    <div className="space-y-8 p-8 relative min-h-screen bg-background text-foreground">
+      <Marquee />
+      <BentoGrid />
+      <AnimatedList />
+      <Globe />
+      <IconCloud />
+      <AnimatedBeam />
+      <BorderBeam>Border Beam Content</BorderBeam>
+      <div className="relative h-40 bg-offBlack"><Meteors /></div>
+      <PixelImage />
+      <Dock />
+    </div>
+  );
+}

--- a/src/components/showcase/animated-beam.tsx
+++ b/src/components/showcase/animated-beam.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export function AnimatedBeam() {
+  return (
+    <div className="relative h-1 w-full overflow-hidden rounded-full bg-gradient-to-r from-mapleRed via-techBlue to-signalYellow">
+      <div className="absolute inset-0 animate-gradient-pan bg-gradient-to-r from-mapleRed via-gold to-techBlue" />
+    </div>
+  );
+}

--- a/src/components/showcase/animated-list.tsx
+++ b/src/components/showcase/animated-list.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+export function AnimatedList() {
+  const items = ['Apply', 'Get Matched', 'Enroll'];
+  return (
+    <ul className="space-y-2">
+      {items.map((item, i) => (
+        <motion.li
+          key={item}
+          className="text-offBlack dark:text-white"
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: i * 0.2 }}
+        >
+          {item}
+        </motion.li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/showcase/bento-grid.tsx
+++ b/src/components/showcase/bento-grid.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export function BentoGrid() {
+  const colors = ['bg-techBlue', 'bg-mapleRed', 'bg-signalYellow', 'bg-offBlack', 'bg-techBlue', 'bg-mapleRed'];
+  return (
+    <div className="grid grid-cols-6 auto-rows-[120px] gap-4">
+      {colors.map((c, i) => (
+        <div
+          key={i}
+          className={`${c} text-white flex items-center justify-center rounded-xl animate-fade-in-up ${i === 0 ? 'col-span-3 row-span-2' : 'col-span-3'}`}
+        >
+          Item {i + 1}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/showcase/border-beam.tsx
+++ b/src/components/showcase/border-beam.tsx
@@ -1,0 +1,10 @@
+import React, { PropsWithChildren } from 'react';
+
+export function BorderBeam({ children }: PropsWithChildren) {
+  return (
+    <div className="relative p-px rounded-xl">
+      <div className="absolute inset-0 rounded-xl animate-gradient-pan bg-gradient-to-r from-techBlue via-mapleRed to-signalYellow" />
+      <div className="relative rounded-xl bg-offBlack p-4 text-white">{children}</div>
+    </div>
+  );
+}

--- a/src/components/showcase/dock.tsx
+++ b/src/components/showcase/dock.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Home, HelpCircle, DollarSign } from 'lucide-react';
+
+export function Dock() {
+  const actions = [
+    { icon: Home, label: 'Quiz' },
+    { icon: DollarSign, label: 'Pricing' },
+    { icon: HelpCircle, label: 'Support' },
+  ];
+  return (
+    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 backdrop-blur bg-offBlack/60 text-white px-4 py-2 rounded-full flex space-x-6">
+      {actions.map(({ icon: Icon, label }) => (
+        <button key={label} className="flex flex-col items-center text-xs">
+          <Icon className="h-5 w-5" />
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/showcase/globe.tsx
+++ b/src/components/showcase/globe.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export function Globe() {
+  return (
+    <div className="w-32 h-32 rounded-full bg-gradient-to-r from-techBlue to-mapleRed animate-spin-slow border-4 border-gold mx-auto" />
+  );
+}

--- a/src/components/showcase/icon-cloud.tsx
+++ b/src/components/showcase/icon-cloud.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Book, Globe2, FileText } from 'lucide-react';
+
+export function IconCloud() {
+  const icons = [Book, Globe2, FileText];
+  return (
+    <div className="relative w-40 h-40 mx-auto animate-spin-slow">
+      {icons.map((Icon, i) => (
+        <Icon
+          key={i}
+          className="text-techBlue absolute"
+          style={{
+            top: `${50 + 40 * Math.sin((i / icons.length) * 2 * Math.PI)}%`,
+            left: `${50 + 40 * Math.cos((i / icons.length) * 2 * Math.PI)}%`,
+            transform: 'translate(-50%, -50%)'
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/showcase/marquee.tsx
+++ b/src/components/showcase/marquee.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export function Marquee() {
+  return (
+    <div className="overflow-hidden whitespace-nowrap bg-offBlack py-2">
+      <div className="animate-marquee inline-block">
+        {["Global Reach", "Trusted Partners", "Scholarships"].map((item) => (
+          <span key={item} className="mx-8 text-white">{item}</span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/showcase/meteors.tsx
+++ b/src/components/showcase/meteors.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export function Meteors() {
+  return (
+    <div className="absolute inset-0 overflow-hidden pointer-events-none">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div
+          key={i}
+          className="absolute top-0 right-0 w-1 h-1 bg-white rounded-full animate-meteor"
+          style={{ animationDelay: `${i}s` }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/showcase/pixel-image.tsx
+++ b/src/components/showcase/pixel-image.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export function PixelImage() {
+  return (
+    <img
+      src="/login-background.jpg"
+      alt="Campus"
+      className="w-64 h-40 object-cover animate-pixelate"
+    />
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -70,8 +70,7 @@ export default {
         gridGray: '#C5C6D0',
         mapleRed: '#E63946',
         signalYellow: '#FFCC00',
-        violetElectric: '#8E2AFF',
-        'electric-violet': '#8E2AFF',
+        gold: '#FFD700',
       },
       borderRadius: {
         lg: 'var(--radius)',
@@ -130,6 +129,18 @@ export default {
           '50%': { 'background-position': '100% 50%' },
           '100%': { 'background-position': '0% 50%' },
         },
+        marquee: {
+          '0%': { transform: 'translateX(0%)' },
+          '100%': { transform: 'translateX(-100%)' },
+        },
+        meteor: {
+          '0%': { transform: 'translateX(0) translateY(0)', opacity: '1' },
+          '100%': { transform: 'translateX(-100vw) translateY(50vh)', opacity: '0' },
+        },
+        pixelate: {
+          '0%': { imageRendering: 'pixelated', filter: 'blur(2px)' },
+          '100%': { imageRendering: 'auto', filter: 'blur(0)' },
+        },
       },
       animation: {
         'accordion-down': 'accordion-down 0.2s ease-out',
@@ -140,6 +151,10 @@ export default {
         'glow-pulse': 'glow-pulse 2s ease-in-out infinite',
         'gradient-pan': 'gradient-pan 12s ease infinite',
         'background-pan': 'background-pan 15s ease-in-out infinite',
+        marquee: 'marquee 20s linear infinite',
+        'spin-slow': 'spin 20s linear infinite',
+        meteor: 'meteor 5s linear infinite',
+        pixelate: 'pixelate 1s ease-out forwards',
       },
     },
   },


### PR DESCRIPTION
## Summary
- limit site colors to off-black, white, blue, red, yellow, and gold
- add animated showcase components and new `/showcase` page
- introduce keyframe animations for marquee, meteors, and pixelated image effects

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities, jsx-no-undef, etc.)*
- `npm run typecheck` *(fails: Firestore parameter is possibly null)*

------
https://chatgpt.com/codex/tasks/task_e_68955913573c8323885251da9c78203a