### PR TITLE
fix node process scheme

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -25,6 +25,14 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  webpack: (config) => {
+    config.resolve = config.resolve || {};
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      'node:process': 'process/browser',
+    };
+    return config;
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- configure webpack alias to resolve `node:process`

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Property 'proofType' does not exist on type 'string'. ...)*
- `npm run build` *(fails: You cannot have two parallel pages that resolve to the same path)*

------
https://chatgpt.com/codex/tasks/task_e_68a47da7545c8323bd483bb461ef37b6