### PR TITLE
feat: add theme provider and utilities

### DIFF
--- a/firebaseClient.ts
+++ b/firebaseClient.ts
@@ -1,0 +1,18 @@
+import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+import { getStorage } from 'firebase/storage';
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export const db = getFirestore(app);
+export const storage = getStorage(app);

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  const token = req.cookies.get('token');
+  const url = req.nextUrl.clone();
+
+  if (!token) {
+    if (url.pathname.startsWith('/admin') || url.pathname.startsWith('/dashboard')) {
+      url.pathname = '/login';
+      return NextResponse.redirect(url);
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/admin/:path*', '/dashboard/:path*'],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "gsap": "^3.13.0",
         "lucide-react": "^0.475.0",
         "next": "15.3.3",
+        "next-themes": "^0.4.6",
         "patch-package": "^8.0.0",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
@@ -14013,6 +14014,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "gsap": "^3.13.0",
     "lucide-react": "^0.475.0",
     "next": "15.3.3",
+    "next-themes": "^0.4.6",
     "patch-package": "^8.0.0",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { AuthProvider } from '@/context/auth-context';
 import { cn } from '@/lib/utils';
 import { archivoBlack, inter } from './fonts';
+import { ThemeProvider } from '@/components/theme-provider';
 
 export const metadata: Metadata = {
   title: 'Maple Leafs Education',
@@ -17,18 +18,20 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="dark">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <link rel="icon" href="/logo.svg" type="image/svg+xml" />
       </head>
-      <body className={cn(
-        "font-body antialiased",
-        inter.variable,
-        archivoBlack.variable
-      )}>
-        <AuthProvider>
-            {children}
-        </AuthProvider>
+      <body
+        className={cn(
+          "font-body antialiased",
+          inter.variable,
+          archivoBlack.variable
+        )}
+      >
+        <ThemeProvider>
+          <AuthProvider>{children}</AuthProvider>
+        </ThemeProvider>
         <Toaster />
       </body>
     </html>

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import { ReactNode } from "react";
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  return (
+    <NextThemesProvider attribute="class" defaultTheme="system" enableSystem>
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/src/components/ui/loader.tsx
+++ b/src/components/ui/loader.tsx
@@ -1,0 +1,7 @@
+export default function Loader() {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center backdrop-blur-md bg-black/30 z-50">
+      <div className="animate-spin h-10 w-10 border-4 border-blue-500 border-t-transparent rounded-full"></div>
+    </div>
+  );
+}

--- a/src/components/ui/notification-center.tsx
+++ b/src/components/ui/notification-center.tsx
@@ -1,0 +1,20 @@
+'use client';
+import { useNotifications } from '@/context/notifications-context';
+
+export default function NotificationCenter() {
+  const { notifications } = useNotifications();
+  return (
+    <div className="absolute right-0 mt-2 w-80 bg-white dark:bg-gray-800 shadow-lg rounded-lg p-4">
+      {notifications.map(n => (
+        <div key={n.id} className="p-2 border-b border-gray-200 dark:border-gray-700">
+          <p className="text-sm">{n.message}</p>
+          {n.timestamp && (
+            <span className="text-xs text-gray-400">
+              {n.timestamp.toDate?.().toLocaleString?.()}
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -1,30 +1,25 @@
+"use client";
 
-"use client"
-
-import * as React from "react"
-import { Moon, Sun } from "lucide-react"
-import { Button } from "@/components/ui/button"
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 export function ThemeToggle() {
-    const [theme, setTheme] = React.useState('light');
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  if (!mounted) return null;
 
-    React.useEffect(() => {
-        const savedTheme = localStorage.getItem('theme') || 'light';
-        setTheme(savedTheme);
-        document.documentElement.classList.toggle('dark', savedTheme === 'dark');
-    }, []);
-
-    const toggleTheme = () => {
-        const newTheme = theme === 'light' ? 'dark' : 'light';
-        setTheme(newTheme);
-        localStorage.setItem('theme', newTheme);
-        document.documentElement.classList.toggle('dark', newTheme === 'dark');
-    };
-
-    return (
-        <Button variant="ghost" size="icon" onClick={toggleTheme} aria-label="Toggle theme">
-            <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-            <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-        </Button>
-    )
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      aria-label="Toggle theme"
+    >
+      <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+    </Button>
+  );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -28,6 +28,12 @@ export default {
         yellow: '#FFCC00',
         green: '#10B981',
         black: '#0F0F0F',
+        brand: {
+          blue: '#2563eb',
+          red: '#dc2626',
+          gold: '#facc15',
+          yellow: '#fbbf24',
+        },
         border: 'hsl(var(--border))',
         input: 'hsl(var(--input))',
         ring: 'hsl(var(--ring))',


### PR DESCRIPTION
## Summary
- add NextThemes provider and button
- extend Tailwind with brand palette
- introduce UI utilities and route middleware

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a48507ec1483238aa3cae646db31ea